### PR TITLE
Use libzmq instead of bundled version on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,13 +1,5 @@
 set DISTUTILS_USE_SDK=1
-
-
-:: For now, we build pyzmq with the bundled zeromq for py<35. There were a number of reasons for
-:: this, including lib\libzmq.dll not being available, as well as
-:: src\stdint.hpp not being available.
-:: https://github.com/conda-forge/staged-recipes/pull/292 has some more detail.
-
 set ZMQ=%LIBRARY_PREFIX%
-set ZMQ=bundled
 
 "%PYTHON%" setup.py configure --zmq "%ZMQ%"
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,23 +10,18 @@ source:
   sha256: 0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d
 
 build:
-  number: 1
+  number: 2
 
-# On Windows ZeroMQ is bundled with pyzmq.
-# On Windows pyzmq includes tweetnacl so libsodium is not used.
-# We should revisit these in the future. However, packaging libsodium
-# on Windows is complicated by the fact that they ship project files,
-# but don't include one for VS 2008, which we would need for Python 2.7.
 requirements:
   build:
-    - pkg-config  # [not win]
+    - pkg-config   # [not win]
     - python
-    - zeromq 4.2*  # [not win]
-    - libsodium   # [not win]
+    - zeromq 4.2*
+    - libsodium    # [not (win and py27)]
   run:
     - python
-    - zeromq 4.2*  # [not win]
-    - libsodium   # [not win]
+    - zeromq 4.2*
+    - libsodium    # [not (win and py27)]
 
 test:
   imports:


### PR DESCRIPTION
Attempt to build with zeromq package on windows.