### PR TITLE
pin_run_as_build libsodium

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,3 +3,6 @@ zeromq:
 pin_run_as_build:
   zeromq:
     max_pin: x.x
+  libsodium:
+    max_pin: x.x.x
+    min_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a72b82ac1910f2cf61a49139f4974f994984475f771b0faa730839607eeedddf
 
 build:
-  number: 1000
+  number: 1001
 
 # On Windows ZeroMQ is bundled with pyzmq.
 # On Windows pyzmq includes tweetnacl so libsodium is not used.


### PR DESCRIPTION
same as https://github.com/conda-forge/zeromq-feedstock/pull/37

since libsodium can make ABI changes in patch releases

closes #38