### PR TITLE
bump build number

### DIFF
--- a/.ci_support/win_c_compilervs2008cxx_compilervs2008python2.7.yaml
+++ b/.ci_support/win_c_compilervs2008cxx_compilervs2008python2.7.yaml
@@ -11,7 +11,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   zeromq:
-    max_pin: x.x
+    min_pin: x.x.x
+    max_pin: x.x.x
 python:
 - '2.7'
 zeromq:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -11,7 +11,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   zeromq:
-    max_pin: x.x
+    min_pin: x.x.x
+    max_pin: x.x.x
 python:
 - '3.6'
 zeromq:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
@@ -11,7 +11,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   zeromq:
-    max_pin: x.x
+    min_pin: x.x.x
+    max_pin: x.x.x
 python:
 - '3.7'
 zeromq:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,7 @@ pin_run_as_build:
   libsodium:
     max_pin: x.x.x
     min_pin: x.x.x
+  zeromq:
+    # zeromq on Windows requires strict pinning
+    min_pin: x.x.x  # [win]
+    max_pin: x.x.x  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 31a11d37ac73107363b47e14c94547dbfc6a550029c3fe0530be443199026fc2
 
 build:
-  number: 0
+  number: 1
 
 # On Windows ZeroMQ is bundled with pyzmq.
 # On Windows pyzmq includes tweetnacl so libsodium is not used.


### PR DESCRIPTION
to get rebuild with fixed run_exports from zeromq (fixes https://github.com/conda-forge/zeromq-feedstock/issues/49)

should get up-to-date libsodium 1.0.17 as well