### PR TITLE
[do not merge] test pyzmq 26 prerelease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+# Ignore all files and folders in root
+*
+!/conda-forge.yml
+
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
+!/recipe/**
+!/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyzmq-feedstock
 
 Home: https://github.com/zeromq/pyzmq
 
-Package license: BSD-3-Clause AND LGPL-3.0-or-later
+Package license: BSD-3-Clause
 
 Summary: Python bindings for zeromq
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,4 @@
-set DISTUTILS_USE_SDK=1
-
-set ZMQ_PREFIX=%LIBRARY_PREFIX%
+set PYZMQ_NO_BUNDLE=1
 
 "%PYTHON%" -m pip install .
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,5 +3,6 @@
 # make sure it doesn't fallback on bundled libzmq
 export PYZMQ_NO_BUNDLE=1
 export SKBUILD_CMAKE_VERBOSE=true
+"${PYTHON}" -m sysconfig
 
 "${PYTHON}" -m pip install -vv .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ]; then
-    # We disable zmq version checking which fails under certain compile conditions.
-    # The tests after building are assertion enough that we have built correctly.
-    echo "[global]" > setup.cfg
-    echo "skip_check_zmq = True" >> setup.cfg
-fi
-export ZMQ_PREFIX=$PREFIX
+# make sure it doesn't fallback on bundled libzmq
+export PYZMQ_NO_BUNDLE=1
 
 "${PYTHON}" -m pip install .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-
+set -x
 # make sure it doesn't fallback on bundled libzmq
 export PYZMQ_NO_BUNDLE=1
 export SKBUILD_CMAKE_VERBOSE=true
 echo $PYTHON
 which python
 $PYTHON -m sysconfig || true
+echo '----'
+$BUILD_PREFIX/venv/bin/python -m sysconfig || true
 
 $PYTHON -m pip install -vv .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,8 @@
 # make sure it doesn't fallback on bundled libzmq
 export PYZMQ_NO_BUNDLE=1
 export SKBUILD_CMAKE_VERBOSE=true
-"${PYTHON}" -m sysconfig
+echo $PYTHON
+which python
+python -m sysconfig
 
-"${PYTHON}" -m pip install -vv .
+python -m pip install -vv .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,5 +2,6 @@
 
 # make sure it doesn't fallback on bundled libzmq
 export PYZMQ_NO_BUNDLE=1
+export SKBUILD_CMAKE_VERBOSE=true
 
-"${PYTHON}" -m pip install .
+"${PYTHON}" -m pip install -vv .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,6 @@ export PYZMQ_NO_BUNDLE=1
 export SKBUILD_CMAKE_VERBOSE=true
 echo $PYTHON
 which python
-python -m sysconfig
+$PYTHON -m sysconfig || true
 
-python -m pip install -vv .
+$PYTHON -m pip install -vv .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,6 @@ echo $PYTHON
 which python
 $PYTHON -m sysconfig || true
 echo '----'
-$BUILD_PREFIX/venv/bin/python -m sysconfig || true
+$BUILD_PREFIX/venv/bin/cross-python -m sysconfig || true
 
 $PYTHON -m pip install -vv .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,11 +5,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pyzmq/pyzmq-{{ version }}.tar.gz
+  # url: https://pypi.io/packages/source/p/pyzmq/pyzmq-{{ version }}.tar.gz
+  url: https://github.com/minrk/pyzmq/archive/debug-skbuild.tar.gz
   # sha256: 97933d06f77cdf2f27199f48c810dd13a9553f716e4a3b7a65d3e5cf172bdb45
 
 build:
   number: 0
+  skip: true  # [target_platform != 'linux-ppc64le']
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,9 @@ test:
   # TestSocket.test_large_send is skipped on upstream CI for pypy
   commands:
     - pip check
+    # workaround weird pytest discovery on pypy's top-level __init__.py
+    # see conda-forge/pycalphad-feedstock#55
+    - pypy -c "import os, pathlib as p, sysconfig as sc; (p.Path(sc.get_paths()['platstdlib'])/ '__init__.py').unlink(missing_ok=True)"  # [python_impl == 'pypy']
     - py.test --pyargs zmq.tests.test_socket  # [not win and python_impl == 'cpython']
     - py.test  -k 'not test_large_send' --pyargs zmq.tests.test_socket  # [not win and python_impl == 'pypy']
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,11 @@ package:
 
 source:
   # url: https://pypi.io/packages/source/p/pyzmq/pyzmq-{{ version }}.tar.gz
-  url: https://github.com/minrk/pyzmq/archive/debug-skbuild.tar.gz
+  url: https://github.com/minrk/pyzmq/archive/skbuild-soabi.tar.gz
   # sha256: 97933d06f77cdf2f27199f48c810dd13a9553f716e4a3b7a65d3e5cf172bdb45
 
 build:
   number: 0
-  skip: true  # [target_platform != 'linux-ppc64le']
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
-{% set version = "25.1.2" %}
+{% set version = "26.0.0a4" %}
 
 package:
   name: pyzmq
   version: {{ version }}
 
 source:
-  # We use the pypi URL as it includes the prepared Cython files.
   url: https://pypi.io/packages/source/p/pyzmq/pyzmq-{{ version }}.tar.gz
-  sha256: 93f1aa311e8bb912e34f004cf186407a4e90eec4f0ecc0efd26056bf7eda0226
+  # sha256: 97933d06f77cdf2f27199f48c810dd13a9553f716e4a3b7a65d3e5cf172bdb45
 
 build:
   number: 0
@@ -19,10 +18,14 @@ requirements:
     - pkg-config  # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmake >=3.28
+    - cython >=3  # [python_impl == 'cpython']
+    - cffi  # [python_impl == 'pypy']
+    - make  # [not win]
   host:
     - python  # should have >=3.5 here, but linter gives spurious errors if we do that
-    - packaging
     - pip
+    - scikit-build-core
     - zeromq
     - libsodium
   run:
@@ -33,8 +36,7 @@ requirements:
 test:
   imports:
     - zmq
-    - zmq.backend.cython.socket  # [python_impl == 'cpython']
-    - zmq.backend.cython.utils   # [python_impl == 'cpython']
+    - zmq.backend.cython  # [python_impl == 'cpython']
     - zmq.backend.cffi           # [python_impl == 'pypy']
     - zmq.devices.monitoredqueue
 
@@ -55,10 +57,9 @@ test:
 about:
   home: https://github.com/zeromq/pyzmq
   summary: Python bindings for zeromq
-  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license: BSD-3-Clause
   license_file:
-    - LICENSE.BSD
-    - LICENSE.LESSER
+    - LICENSE.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
pyzmq 26 is now built with scikit-build-core instead of setuptools.

Checking to see if I'm breaking anything on conda-forge (especially curious about cross-compiling).

Relevant packaging changes:

- build system is totally different (requires cmake, ninja, setup.cfg doesn't exist)
- cython is a build-time dependency
- license is purely BSD