### PR TITLE
Rebuild with libsodium 1.0.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -34,8 +34,6 @@ requirements:
     - libsodium
   run:
     - python
-    - zeromq
-    - libsodium
 
 test:
   source_files:


### PR DESCRIPTION
Just rerendering and building the build number to pick up the latest build of libsodium and zeromq.

Follow up on https://github.com/conda-forge/zeromq-feedstock/pull/76.